### PR TITLE
Add public template library management features

### DIFF
--- a/cardforge/src/types/index.ts
+++ b/cardforge/src/types/index.ts
@@ -80,6 +80,8 @@ export type TemplateElement =
   | TemplateRectangleElement
   | TemplateImageElement
 
+export type TemplateVisibility = 'private' | 'public'
+
 export interface Template {
   id: string
   ownerUid: string
@@ -88,6 +90,7 @@ export interface Template {
   height: number
   background: string
   showGrid: boolean
+  visibility: TemplateVisibility
   elements: TemplateElement[]
   createdAt?: Date
   updatedAt?: Date
@@ -96,6 +99,9 @@ export interface Template {
 export interface TemplateSummary {
   id: string
   name: string
+  ownerUid: string
+  visibility: TemplateVisibility
+  isOwner: boolean
   updatedAt?: Date
 }
 


### PR DESCRIPTION
## Summary
- extend template persistence to track visibility, list public entries, and clone shared templates into a user's library
- enhance the template editor with separate personal/public sections, clone actions, and read-only safeguards for shared templates
- surface template visibility settings so authors can publish or keep designs private

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d397462ba0832c89b597d5a5063a90