### PR TITLE
Add data import flow for bulk card automation

### DIFF
--- a/cardforge/src/components/DataImportDialog.tsx
+++ b/cardforge/src/components/DataImportDialog.tsx
@@ -1,0 +1,422 @@
+import {
+  ChangeEvent,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+import {
+  CARD_IMPORT_FIELDS,
+  autoMapImportFields,
+  convertRecordsToImportedCards,
+  parseCsvDataset,
+  parseJsonDataset,
+  sanitizeFieldMapping,
+  type DataImportResult,
+  type DatasetParseResult,
+  type ImportFieldMapping,
+} from '../lib/dataImport'
+
+interface DataImportDialogProps {
+  open: boolean
+  onClose: () => void
+  onImport: (result: DataImportResult) => void
+}
+
+type CsvDelimiterOption = 'auto' | ',' | ';' | '\t' | '|'
+
+const formatIconSeparator = (value: string): string => {
+  if (!value) {
+    return ','
+  }
+  return value.slice(0, 3)
+}
+
+const PREVIEW_FIELDS: Array<{ key: keyof DataImportResult['entries'][number]; label: string }> = [
+  { key: 'id', label: 'ID' },
+  { key: 'title', label: 'Título' },
+  { key: 'type', label: 'Tipo' },
+  { key: 'value', label: 'Valor' },
+  { key: 'action', label: 'Acción' },
+  { key: 'actionDescription', label: 'Descripción' },
+  { key: 'context', label: 'Contexto' },
+  { key: 'imageDescription', label: 'Imagen' },
+  { key: 'icons', label: 'Iconos' },
+  { key: 'imageUrl', label: 'URL de imagen' },
+]
+
+const DataImportDialog = ({ open, onClose, onImport }: DataImportDialogProps) => {
+  const [rawInput, setRawInput] = useState('')
+  const [format, setFormat] = useState<'csv' | 'json'>('csv')
+  const [delimiter, setDelimiter] = useState<CsvDelimiterOption>('auto')
+  const [dataset, setDataset] = useState<DatasetParseResult | null>(null)
+  const [mapping, setMapping] = useState<ImportFieldMapping>({})
+  const [parseError, setParseError] = useState<string | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [iconSeparator, setIconSeparator] = useState(',')
+  const [updateExisting, setUpdateExisting] = useState(true)
+  const [sourceName, setSourceName] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open, onClose])
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    setRawInput('')
+    setDataset(null)
+    setMapping({})
+    setParseError(null)
+    setSubmitError(null)
+    setIconSeparator(',')
+    setUpdateExisting(true)
+    setSourceName(undefined)
+    setFormat('csv')
+    setDelimiter('auto')
+  }, [open])
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    if (!rawInput.trim()) {
+      setDataset(null)
+      setParseError(null)
+      return
+    }
+
+    try {
+      const nextDataset =
+        format === 'csv'
+          ? parseCsvDataset(rawInput, delimiter === 'auto' ? undefined : delimiter)
+          : parseJsonDataset(rawInput)
+      setDataset(nextDataset)
+      setParseError(null)
+      setMapping((current) => {
+        const sanitized = sanitizeFieldMapping(current, nextDataset.columns)
+        const hasSelection = Object.values(sanitized).some(Boolean)
+        if (hasSelection) {
+          return sanitized
+        }
+        return autoMapImportFields(nextDataset.columns)
+      })
+    } catch (error) {
+      setDataset(null)
+      setParseError(error instanceof Error ? error.message : 'No se pudo interpretar el contenido.')
+    }
+  }, [delimiter, format, open, rawInput])
+
+  const mappedColumnsCount = useMemo(
+    () => Object.values(mapping).filter((value) => Boolean(value)).length,
+    [mapping],
+  )
+
+  const conversionSummary = useMemo(() => {
+    if (!dataset || mappedColumnsCount === 0) {
+      return null
+    }
+    return convertRecordsToImportedCards(dataset.records, mapping, { iconSeparator })
+  }, [dataset, iconSeparator, mappedColumnsCount, mapping])
+
+  const combinedWarnings = useMemo(() => {
+    const warnings: string[] = []
+    if (dataset?.warnings) {
+      warnings.push(...dataset.warnings)
+    }
+    if (conversionSummary?.warnings) {
+      warnings.push(...conversionSummary.warnings)
+    }
+    return warnings
+  }, [conversionSummary?.warnings, dataset?.warnings])
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) {
+      return
+    }
+    setSourceName(file.name)
+    const reader = new FileReader()
+    reader.onload = () => {
+      const text = typeof reader.result === 'string' ? reader.result : ''
+      setRawInput(text)
+      const extension = file.name.toLowerCase().split('.').pop()
+      if (extension === 'json') {
+        setFormat('json')
+      } else if (extension === 'csv' || extension === 'txt') {
+        setFormat('csv')
+      }
+    }
+    reader.readAsText(file)
+  }
+
+  const handleImport = () => {
+    setSubmitError(null)
+    if (!dataset) {
+      setSubmitError('No hay datos que importar. Verifica el contenido proporcionado.')
+      return
+    }
+    if (!conversionSummary || conversionSummary.entries.length === 0) {
+      setSubmitError('Asigna al menos una columna válida para generar cartas.')
+      return
+    }
+
+    onImport({
+      ...conversionSummary,
+      warnings: combinedWarnings,
+      updateExisting,
+      sourceName,
+    })
+    onClose()
+  }
+
+  const previewEntries = conversionSummary ? conversionSummary.entries.slice(0, 5) : []
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 p-4"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className="max-h-[90vh] w-full max-w-5xl overflow-hidden rounded-2xl border border-slate-800 bg-slate-900 text-slate-100 shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
+        <header className="flex items-start justify-between border-b border-slate-800 bg-slate-900/80 px-6 py-4">
+          <div>
+            <h2 className="text-lg font-semibold text-white">Importar datos estructurados</h2>
+            <p className="text-sm text-slate-400">
+              Automatiza la creación de cartas a partir de archivos CSV o JSON. Ajusta el mapeo de campos antes de aplicar los
+              cambios.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-slate-700 px-3 py-1 text-sm text-slate-200 hover:bg-slate-800"
+          >
+            Cerrar
+          </button>
+        </header>
+        <div className="flex max-h-[70vh] flex-col gap-6 overflow-y-auto px-6 py-6 text-sm">
+          <section className="flex flex-col gap-4">
+            <h3 className="text-base font-semibold text-white">Origen de datos</h3>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="flex flex-col gap-2 text-sm text-slate-200">
+                <span>Archivo CSV o JSON</span>
+                <input type="file" accept=".csv,.json,.txt" onChange={handleFileChange} />
+                {sourceName ? <span className="text-xs text-slate-400">Archivo seleccionado: {sourceName}</span> : null}
+              </label>
+              <label className="flex flex-col gap-2 text-sm text-slate-200">
+                <span>Formato</span>
+                <select
+                  value={format}
+                  onChange={(event) => setFormat(event.target.value === 'json' ? 'json' : 'csv')}
+                  className="rounded border border-slate-700 bg-slate-800/60 px-2 py-1"
+                >
+                  <option value="csv">CSV</option>
+                  <option value="json">JSON</option>
+                </select>
+              </label>
+              {format === 'csv' ? (
+                <label className="flex flex-col gap-2 text-sm text-slate-200">
+                  <span>Delimitador</span>
+                  <select
+                    value={delimiter}
+                    onChange={(event) => setDelimiter(event.target.value as CsvDelimiterOption)}
+                    className="rounded border border-slate-700 bg-slate-800/60 px-2 py-1"
+                  >
+                    <option value="auto">Detección automática</option>
+                    <option value=",">Coma (,)</option>
+                    <option value=";">Punto y coma (;)</option>
+                    <option value="\t">Tabulación</option>
+                    <option value="|">Barra vertical (|)</option>
+                  </select>
+                  {dataset?.delimiter ? (
+                    <span className="text-xs text-slate-400">Delimitador detectado: “{dataset.delimiter}”.</span>
+                  ) : null}
+                </label>
+              ) : null}
+              <label className="flex flex-col gap-2 text-sm text-slate-200">
+                <span>Separador de iconos</span>
+                <input
+                  value={iconSeparator}
+                  onChange={(event) => setIconSeparator(formatIconSeparator(event.target.value))}
+                  maxLength={3}
+                  className="rounded border border-slate-700 bg-slate-800/60 px-2 py-1"
+                />
+                <span className="text-xs text-slate-400">Separa múltiples iconos dentro de la misma celda.</span>
+              </label>
+            </div>
+            <label className="flex flex-col gap-2 text-sm text-slate-200">
+              <span>Contenido</span>
+              <textarea
+                value={rawInput}
+                onChange={(event) => setRawInput(event.target.value)}
+                rows={8}
+                className="min-h-[180px] rounded-lg border border-slate-800 bg-slate-950/60 p-3 font-mono text-xs text-slate-200"
+                placeholder="Pega aquí datos CSV o JSON si no deseas usar un archivo."
+              />
+            </label>
+            {parseError ? <p className="text-sm text-red-400">{parseError}</p> : null}
+          </section>
+          {dataset ? (
+            <section className="flex flex-col gap-4">
+              <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h3 className="text-base font-semibold text-white">Mapeo de campos</h3>
+                  <p className="text-xs text-slate-400">
+                    Asocia las columnas del archivo con los campos de la plantilla. Las columnas no asignadas se ignorarán.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setMapping(autoMapImportFields(dataset.columns))}
+                  className="self-start rounded-md border border-slate-700 px-3 py-1 text-xs text-slate-200 hover:bg-slate-800"
+                >
+                  Reasignar automáticamente
+                </button>
+              </header>
+              <div className="grid gap-3 md:grid-cols-2">
+                {CARD_IMPORT_FIELDS.map((field) => (
+                  <label key={field.field} className="flex flex-col gap-1 text-sm text-slate-200">
+                    <span className="font-medium text-slate-100">{field.label}</span>
+                    <select
+                      value={mapping[field.field] ?? ''}
+                      onChange={(event) =>
+                        setMapping((current) => ({
+                          ...current,
+                          [field.field]: event.target.value || undefined,
+                        }))
+                      }
+                      className="rounded border border-slate-700 bg-slate-800/60 px-2 py-1 text-sm"
+                    >
+                      <option value="">No importar</option>
+                      {dataset.columns.map((column) => (
+                        <option key={column} value={column}>
+                          {column}
+                        </option>
+                      ))}
+                    </select>
+                    {field.description ? (
+                      <span className="text-xs text-slate-400">{field.description}</span>
+                    ) : null}
+                  </label>
+                ))}
+              </div>
+              <label className="inline-flex items-center gap-2 text-sm text-slate-200">
+                <input
+                  type="checkbox"
+                  checked={updateExisting}
+                  onChange={(event) => setUpdateExisting(event.target.checked)}
+                />
+                <span>Actualizar cartas existentes si coincide el ID</span>
+              </label>
+              <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-3 text-xs text-slate-300">
+                <p>Columnas detectadas: {dataset.columns.length || 0}.</p>
+                <p>Registros analizados: {dataset.records.length}.</p>
+                {conversionSummary ? (
+                  <p>
+                    Cartas listas para importar: {conversionSummary.entries.length}. Filas omitidas: {conversionSummary.skipped}.
+                  </p>
+                ) : (
+                  <p>Selecciona al menos una columna para habilitar la importación.</p>
+                )}
+              </div>
+              {combinedWarnings.length ? (
+                <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-200">
+                  <p className="font-semibold">Avisos</p>
+                  <ul className="list-disc pl-5">
+                    {combinedWarnings.slice(0, 4).map((warning) => (
+                      <li key={warning}>{warning}</li>
+                    ))}
+                    {combinedWarnings.length > 4 ? (
+                      <li>Se omitieron {combinedWarnings.length - 4} avisos adicionales.</li>
+                    ) : null}
+                  </ul>
+                </div>
+              ) : null}
+              {previewEntries.length ? (
+                <div className="overflow-x-auto">
+                  <table className="min-w-full divide-y divide-slate-800 text-xs text-slate-200">
+                    <thead>
+                      <tr>
+                        {PREVIEW_FIELDS.map((field) => (
+                          <th key={field.key as string} className="px-3 py-2 text-left font-semibold">
+                            {field.label}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-800">
+                      {previewEntries.map((entry, index) => (
+                        <tr key={`${entry.id ?? 'fila'}_${index}`} className="odd:bg-slate-900/40">
+                          {PREVIEW_FIELDS.map((field) => {
+                            const value = entry[field.key]
+                            if (Array.isArray(value)) {
+                              return (
+                                <td key={field.key as string} className="px-3 py-2">
+                                  {value.join(', ')}
+                                </td>
+                              )
+                            }
+                            return (
+                              <td key={field.key as string} className="px-3 py-2">
+                                {value ?? '—'}
+                              </td>
+                            )
+                          })}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : null}
+            </section>
+          ) : null}
+        </div>
+        <footer className="flex flex-col gap-3 border-t border-slate-800 bg-slate-900/80 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-xs text-slate-400">
+            {submitError ? <p className="text-red-400">{submitError}</p> : <p>Revisa el resumen antes de importar.</p>}
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-slate-700 px-4 py-2 text-sm text-slate-200 hover:bg-slate-800"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={handleImport}
+              disabled={!conversionSummary || conversionSummary.entries.length === 0}
+              className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+            >
+              Importar datos
+            </button>
+          </div>
+        </footer>
+      </div>
+    </div>
+  )
+}
+
+export default DataImportDialog

--- a/cardforge/src/components/ProjectActions.tsx
+++ b/cardforge/src/components/ProjectActions.tsx
@@ -5,6 +5,7 @@ interface ProjectActionsProps {
   onRename: (newName: string) => Promise<void> | void
   onSave: () => void
   onNewCard: () => void
+  onImportData: () => void
   onGenerateText: () => void
   onGenerateImage: () => void
   onDelete: () => void
@@ -22,6 +23,7 @@ const ProjectActions = ({
   onRename,
   onSave,
   onNewCard,
+  onImportData,
   onGenerateText,
   onGenerateImage,
   onDelete,
@@ -88,6 +90,13 @@ const ProjectActions = ({
       <div className="flex flex-wrap gap-2 text-sm">
         <button type="button" onClick={onNewCard} className="bg-primary px-4 py-2">
           Nueva carta
+        </button>
+        <button
+          type="button"
+          onClick={onImportData}
+          className="bg-emerald-700 px-4 py-2 text-white hover:bg-emerald-600"
+        >
+          Importar CSV/JSON
         </button>
         <button type="button" onClick={onSave} disabled={isSaving} className="bg-slate-700 px-4 py-2">
           {isSaving ? 'Guardando...' : 'Guardar'}

--- a/cardforge/src/lib/__tests__/dataImport.test.ts
+++ b/cardforge/src/lib/__tests__/dataImport.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import {
+  autoMapImportFields,
+  convertRecordsToImportedCards,
+  parseCsvDataset,
+  parseJsonDataset,
+  type ImportFieldMapping,
+} from '../dataImport'
+
+const createRecord = (rowNumber: number, values: Record<string, unknown>) => ({
+  rowNumber,
+  values,
+})
+
+describe('parseCsvDataset', () => {
+  it('interpreta encabezados y valores básicos', () => {
+    const csv = `titulo,tipo,valor\nGuerrero,Personaje,3\n`;
+    const result = parseCsvDataset(csv)
+    expect(result.columns).toEqual(['titulo', 'tipo', 'valor'])
+    expect(result.records).toHaveLength(1)
+    expect(result.records[0].rowNumber).toBe(2)
+    expect(result.records[0].values.titulo).toBe('Guerrero')
+    expect(result.records[0].values.valor).toBe('3')
+    expect(result.warnings).toHaveLength(0)
+  })
+
+  it('detecta delimitadores y preserva valores entrecomillados', () => {
+    const csv = 'titulo;descripcion;iconos\n"Espada";"Golpea, ""doble""";fuego,acero\n'
+    const result = parseCsvDataset(csv)
+    expect(result.columns).toEqual(['titulo', 'descripcion', 'iconos'])
+    expect(result.delimiter).toBe(';')
+    expect(result.records[0].values.descripcion).toBe('Golpea, "doble"')
+    expect(result.records[0].values.iconos).toBe('fuego,acero')
+  })
+})
+
+describe('parseJsonDataset', () => {
+  it('extrae objetos desde un arreglo y reporta descartes', () => {
+    const json = JSON.stringify([
+      { titulo: 'Mago', descripcion: 'Hechizo básico' },
+      'invalido',
+      { titulo: 'Arquera', valor: 2 },
+    ])
+    const result = parseJsonDataset(json)
+    expect(result.columns.sort()).toEqual(['descripcion', 'titulo', 'valor'])
+    expect(result.records).toHaveLength(2)
+    expect(result.records[0].values.titulo).toBe('Mago')
+    expect(result.warnings[0]).toContain('Se omitieron 1 registros')
+  })
+})
+
+describe('autoMapImportFields', () => {
+  it('asigna columnas coincidentes con sinónimos', () => {
+    const columns = ['Titulo', 'descripcion', 'ICONOS', 'ancho', 'alto']
+    const mapping = autoMapImportFields(columns)
+    expect(mapping.title).toBe('Titulo')
+    expect(mapping.actionDescription).toBe('descripcion')
+    expect(mapping.icons).toBe('ICONOS')
+    expect(mapping.sizeWidth).toBe('ancho')
+    expect(mapping.sizeHeight).toBe('alto')
+  })
+})
+
+describe('convertRecordsToImportedCards', () => {
+  it('convierte registros en cartas normalizadas', () => {
+    const mapping: ImportFieldMapping = {
+      title: 'titulo',
+      actionDescription: 'descripcion',
+      icons: 'iconos',
+      sizeWidth: 'ancho',
+      sizeHeight: 'alto',
+    }
+    const records = [
+      createRecord(2, {
+        titulo: 'Invocador',
+        descripcion: 'Llama a criaturas de apoyo.',
+        iconos: 'fuego, sombra ,  ',
+        ancho: '63',
+        alto: '88',
+      }),
+    ]
+
+    const result = convertRecordsToImportedCards(records, mapping, { iconSeparator: ',' })
+    expect(result.entries).toHaveLength(1)
+    expect(result.entries[0].title).toBe('Invocador')
+    expect(result.entries[0].icons).toEqual(['fuego', 'sombra'])
+    expect(result.entries[0].size?.width).toBe(63)
+    expect(result.entries[0].size?.presetId).toBeDefined()
+    expect(result.skipped).toBe(0)
+  })
+
+  it('reporta advertencias de valores numéricos inválidos', () => {
+    const mapping: ImportFieldMapping = {
+      id: 'identificador',
+      sizeWidth: 'ancho',
+      sizeHeight: 'alto',
+    }
+    const records = [
+      createRecord(4, {
+        identificador: 'carta_01',
+        ancho: 'invalid',
+        alto: '120',
+      }),
+    ]
+
+    const result = convertRecordsToImportedCards(records, mapping)
+    expect(result.entries).toHaveLength(1)
+    expect(result.entries[0].size?.height).toBe(120)
+    expect(result.entries[0].size?.width).toBeUndefined()
+    expect(result.warnings[0]).toContain('Fila 4: el valor de ancho "invalid" no es válido.')
+  })
+
+  it('omite filas sin datos relevantes', () => {
+    const mapping: ImportFieldMapping = { title: 'titulo' }
+    const records = [createRecord(3, { titulo: '  ' }), createRecord(4, { titulo: 'Vigía' })]
+    const result = convertRecordsToImportedCards(records, mapping)
+    expect(result.entries).toHaveLength(1)
+    expect(result.entries[0].title).toBe('Vigía')
+    expect(result.skipped).toBe(1)
+  })
+})

--- a/cardforge/src/lib/dataImport.ts
+++ b/cardforge/src/lib/dataImport.ts
@@ -1,0 +1,528 @@
+import { CUSTOM_CARD_SIZE_ID, findMatchingPresetId } from './cardSizes'
+
+export type CardImportField =
+  | 'id'
+  | 'title'
+  | 'type'
+  | 'value'
+  | 'action'
+  | 'actionDescription'
+  | 'context'
+  | 'imageDescription'
+  | 'icons'
+  | 'imageUrl'
+  | 'sizePresetId'
+  | 'sizeWidth'
+  | 'sizeHeight'
+  | 'sizeUnit'
+
+export interface ImportFieldDefinition {
+  field: CardImportField
+  label: string
+  description?: string
+  synonyms: string[]
+}
+
+export const CARD_IMPORT_FIELDS: ImportFieldDefinition[] = [
+  {
+    field: 'id',
+    label: 'ID',
+    description: 'Identificador único opcional. Si coincide con una carta existente puede actualizarla.',
+    synonyms: ['id', 'identificador', 'codigo', 'code', 'cardid'],
+  },
+  {
+    field: 'title',
+    label: 'Título',
+    synonyms: ['titulo', 'title', 'nombre', 'name'],
+  },
+  {
+    field: 'type',
+    label: 'Tipo',
+    synonyms: ['tipo', 'type', 'category', 'categoria'],
+  },
+  {
+    field: 'value',
+    label: 'Valor',
+    synonyms: ['valor', 'value', 'coste', 'cost', 'poder', 'power'],
+  },
+  {
+    field: 'action',
+    label: 'Acción corta',
+    synonyms: ['accion', 'action', 'resumen', 'summary', 'subtitle'],
+  },
+  {
+    field: 'actionDescription',
+    label: 'Descripción de la acción',
+    synonyms: ['descripcion', 'description', 'textolargo', 'rules', 'actiondescription', 'effect', 'ability'],
+  },
+  {
+    field: 'context',
+    label: 'Contexto',
+    synonyms: ['contexto', 'context', 'lore', 'ambientacion', 'setting'],
+  },
+  {
+    field: 'imageDescription',
+    label: 'Descripción de imagen',
+    synonyms: ['imagedescription', 'prompt', 'imagen', 'arte', 'imageprompt', 'artprompt'],
+  },
+  {
+    field: 'icons',
+    label: 'Iconos',
+    description: 'Lista separada por comas o múltiples valores.',
+    synonyms: ['iconos', 'icons', 'simbolos', 'tags'],
+  },
+  {
+    field: 'imageUrl',
+    label: 'URL de imagen',
+    synonyms: ['image', 'imageurl', 'urlimagen', 'arturl'],
+  },
+  {
+    field: 'sizePresetId',
+    label: 'Formato/tamaño',
+    description: 'ID del preset de tamaño (p. ej. poker, tarot).',
+    synonyms: ['formato', 'preset', 'size', 'sizepreset', 'tamano'],
+  },
+  {
+    field: 'sizeWidth',
+    label: 'Ancho (mm)',
+    synonyms: ['ancho', 'width', 'anchomm', 'sizewidth'],
+  },
+  {
+    field: 'sizeHeight',
+    label: 'Alto (mm)',
+    synonyms: ['alto', 'height', 'altomm', 'sizeheight'],
+  },
+  {
+    field: 'sizeUnit',
+    label: 'Unidad tamaño',
+    description: 'Unidad opcional (solo mm soportado actualmente).',
+    synonyms: ['unidad', 'unit', 'sizeunit'],
+  },
+]
+
+export interface DatasetRecord {
+  rowNumber: number
+  values: Record<string, unknown>
+}
+
+export interface DatasetParseResult {
+  records: DatasetRecord[]
+  columns: string[]
+  warnings: string[]
+  delimiter?: string
+}
+
+export interface ImportedCardSize {
+  presetId?: string
+  width?: number
+  height?: number
+  unit?: 'mm'
+}
+
+export interface ImportedCardData {
+  id?: string
+  title?: string
+  type?: string
+  value?: string
+  action?: string
+  actionDescription?: string
+  context?: string
+  imageDescription?: string
+  icons?: string[]
+  imageUrl?: string
+  size?: ImportedCardSize
+}
+
+export type ImportFieldMapping = Partial<Record<CardImportField, string>>
+
+export interface RecordsConversionResult {
+  entries: ImportedCardData[]
+  skipped: number
+  warnings: string[]
+}
+
+export interface DataImportResult extends RecordsConversionResult {
+  updateExisting: boolean
+  sourceName?: string
+}
+
+const normalizeToken = (value: string) => value.toLowerCase().replace(/[^a-z0-9]/g, '')
+
+const detectDelimiter = (line: string): string => {
+  const candidates = [',', ';', '\t', '|']
+  let best = ','
+  let bestCount = -1
+  candidates.forEach((delimiter) => {
+    const count = line.split(delimiter).length
+    if (count > bestCount) {
+      best = delimiter
+      bestCount = count
+    }
+  })
+  return best
+}
+
+const parseCsvLine = (line: string, delimiter: string): string[] => {
+  const result: string[] = []
+  let current = ''
+  let inQuotes = false
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]
+    if (char === '"') {
+      const nextChar = line[index + 1]
+      if (inQuotes && nextChar === '"') {
+        current += '"'
+        index += 1
+      } else {
+        inQuotes = !inQuotes
+      }
+    } else if (char === delimiter && !inQuotes) {
+      result.push(current)
+      current = ''
+    } else {
+      current += char
+    }
+  }
+
+  result.push(current)
+  return result
+}
+
+const trimBom = (value: string) => value.replace(/^\ufeff/, '')
+
+export const parseCsvDataset = (raw: string, forcedDelimiter?: string): DatasetParseResult => {
+  const normalizedInput = trimBom(raw ?? '')
+  const lines = normalizedInput
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line, index, array) => line.length > 0 || index === 0 || index === array.length - 1)
+    .filter((line) => line.length > 0)
+
+  if (!lines.length) {
+    return { records: [], columns: [], warnings: [], delimiter: forcedDelimiter }
+  }
+
+  const delimiter = forcedDelimiter ?? detectDelimiter(lines[0])
+  const headerTokens = parseCsvLine(lines[0], delimiter).map((token, index) =>
+    token.trim() || `columna_${index + 1}`,
+  )
+  const columns = Array.from(new Set(headerTokens))
+  const warnings: string[] = []
+  const records: DatasetRecord[] = []
+
+  for (let i = 1; i < lines.length; i += 1) {
+    const line = lines[i]
+    if (!line.trim()) {
+      continue
+    }
+    const tokens = parseCsvLine(line, delimiter)
+    if (tokens.length !== headerTokens.length) {
+      warnings.push(
+        `Fila ${i + 1}: se esperaban ${headerTokens.length} columnas y se recibieron ${tokens.length}. Se ajustó automáticamente.`,
+      )
+    }
+
+    const normalizedTokens = [...tokens]
+    if (tokens.length > headerTokens.length) {
+      const extras = normalizedTokens.splice(headerTokens.length - 1)
+      normalizedTokens[headerTokens.length - 1] = `${normalizedTokens[headerTokens.length - 1] ?? ''}${delimiter}${extras.join(delimiter)}`
+    } else if (tokens.length < headerTokens.length) {
+      while (normalizedTokens.length < headerTokens.length) {
+        normalizedTokens.push('')
+      }
+    }
+
+    const values: Record<string, unknown> = {}
+    headerTokens.forEach((key, index) => {
+      const rawValue = normalizedTokens[index] ?? ''
+      const trimmed = rawValue.trim()
+      values[key] = trimmed
+    })
+
+    const hasData = Object.values(values).some((value) =>
+      typeof value === 'string' ? value.trim().length > 0 : value !== undefined && value !== null,
+    )
+    if (!hasData) {
+      continue
+    }
+
+    records.push({ rowNumber: i + 1, values })
+  }
+
+  return { records, columns, warnings, delimiter }
+}
+
+export const parseJsonDataset = (raw: string): DatasetParseResult => {
+  const input = trimBom(raw ?? '')
+  if (!input.trim()) {
+    return { records: [], columns: [], warnings: [] }
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(input)
+  } catch (error) {
+    throw new Error('No se pudo interpretar el contenido como JSON válido.')
+  }
+
+  const warnings: string[] = []
+  let candidates: unknown[] = []
+
+  if (Array.isArray(parsed)) {
+    candidates = parsed
+  } else if (parsed && typeof parsed === 'object') {
+    const container = parsed as Record<string, unknown>
+    const preferredKeys = ['records', 'data', 'items', 'cards', 'rows']
+    for (const key of preferredKeys) {
+      const value = container[key]
+      if (Array.isArray(value)) {
+        candidates = value
+        break
+      }
+    }
+    if (!candidates.length) {
+      candidates = Object.values(container)
+    }
+  } else {
+    throw new Error('El JSON debe ser un arreglo de objetos o contener un arreglo en una propiedad de alto nivel.')
+  }
+
+  const records: DatasetRecord[] = []
+  const columnsSet = new Set<string>()
+  let discarded = 0
+
+  candidates.forEach((item, index) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      discarded += 1
+      return
+    }
+    const values = item as Record<string, unknown>
+    Object.keys(values).forEach((key) => columnsSet.add(key))
+    records.push({ rowNumber: index + 1, values })
+  })
+
+  if (discarded > 0) {
+    warnings.push(`Se omitieron ${discarded} registros que no tenían formato de objeto.`)
+  }
+
+  return { records, columns: Array.from(columnsSet), warnings }
+}
+
+export const sanitizeFieldMapping = (
+  mapping: ImportFieldMapping,
+  columns: string[],
+): ImportFieldMapping => {
+  const validColumns = new Set(columns)
+  const sanitized: ImportFieldMapping = {}
+  Object.entries(mapping).forEach(([field, column]) => {
+    if (column && validColumns.has(column)) {
+      sanitized[field as CardImportField] = column
+    }
+  })
+  return sanitized
+}
+
+export const autoMapImportFields = (columns: string[]): ImportFieldMapping => {
+  const normalizedColumns = columns.map((column) => ({
+    original: column,
+    normalized: normalizeToken(column),
+  }))
+
+  const mapping: ImportFieldMapping = {}
+  const usedColumns = new Set<string>()
+
+  const pickColumn = (synonyms: string[]): string | undefined => {
+    const normalizedSynonyms = synonyms.map(normalizeToken)
+    for (const synonym of normalizedSynonyms) {
+      const match = normalizedColumns.find(
+        (column) => !usedColumns.has(column.original) && column.normalized === synonym,
+      )
+      if (match) {
+        return match.original
+      }
+    }
+    for (const synonym of normalizedSynonyms) {
+      const match = normalizedColumns.find(
+        (column) => !usedColumns.has(column.original) && column.normalized.includes(synonym),
+      )
+      if (match) {
+        return match.original
+      }
+    }
+    return undefined
+  }
+
+  CARD_IMPORT_FIELDS.forEach((definition) => {
+    const column = pickColumn(definition.synonyms)
+    if (column) {
+      mapping[definition.field] = column
+      usedColumns.add(column)
+    }
+  })
+
+  return mapping
+}
+
+const coerceText = (value: unknown): string | undefined => {
+  if (value === undefined || value === null) {
+    return undefined
+  }
+  if (typeof value === 'string') {
+    return value.trim()
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+  return undefined
+}
+
+const parseNumberValue = (value: unknown): number | undefined => {
+  if (value === undefined || value === null) {
+    return undefined
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  if (typeof value === 'string') {
+    const normalized = value.replace(/,/g, '.').trim()
+    if (!normalized) {
+      return undefined
+    }
+    const parsed = Number(normalized)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+  return undefined
+}
+
+const mapRecordToCard = (
+  record: DatasetRecord,
+  mapping: ImportFieldMapping,
+  options: { iconSeparator?: string },
+): { card: ImportedCardData | null; warnings: string[] } => {
+  const warnings: string[] = []
+  const values = record.values
+
+  const getValue = (field: CardImportField) => {
+    const column = mapping[field]
+    if (!column) {
+      return undefined
+    }
+    return values[column]
+  }
+
+  const id = coerceText(getValue('id'))
+  const title = coerceText(getValue('title'))
+  const type = coerceText(getValue('type'))
+  const value = coerceText(getValue('value'))
+  const action = coerceText(getValue('action'))
+  const actionDescription = coerceText(getValue('actionDescription'))
+  const context = coerceText(getValue('context'))
+  const imageDescription = coerceText(getValue('imageDescription'))
+  const imageUrl = coerceText(getValue('imageUrl'))
+
+  const rawIcons = getValue('icons')
+  let icons: string[] | undefined
+
+  if (Array.isArray(rawIcons)) {
+    icons = rawIcons
+      .map((item) => coerceText(item) ?? '')
+      .map((token) => token.trim())
+      .filter((token) => token.length > 0)
+  } else {
+    const textIcons = coerceText(rawIcons)
+    if (textIcons && textIcons.length > 0) {
+      const separator = options.iconSeparator ?? ','
+      icons = textIcons
+        .split(separator)
+        .map((token) => token.trim())
+        .filter((token) => token.length > 0)
+    } else if (rawIcons !== undefined && rawIcons !== null) {
+      icons = []
+    }
+  }
+
+  const presetIdRaw = coerceText(getValue('sizePresetId'))
+  const widthRaw = getValue('sizeWidth')
+  const heightRaw = getValue('sizeHeight')
+  const unitRaw = coerceText(getValue('sizeUnit'))
+
+  const width = parseNumberValue(widthRaw)
+  if (widthRaw !== undefined && widthRaw !== null && width === undefined) {
+    warnings.push(`Fila ${record.rowNumber}: el valor de ancho "${widthRaw}" no es válido.`)
+  }
+  const height = parseNumberValue(heightRaw)
+  if (heightRaw !== undefined && heightRaw !== null && height === undefined) {
+    warnings.push(`Fila ${record.rowNumber}: el valor de alto "${heightRaw}" no es válido.`)
+  }
+
+  let presetId = presetIdRaw
+  if (!presetId && width !== undefined && height !== undefined) {
+    presetId = findMatchingPresetId(width, height) ?? CUSTOM_CARD_SIZE_ID
+  }
+
+  const size: ImportedCardSize | undefined =
+    presetId || width !== undefined || height !== undefined || unitRaw
+      ? {
+          presetId: presetId ?? undefined,
+          width: width ?? undefined,
+          height: height ?? undefined,
+          unit: unitRaw === 'mm' ? 'mm' : undefined,
+        }
+      : undefined
+
+  const hasContent =
+    Boolean(id) ||
+    Boolean(title) ||
+    Boolean(type) ||
+    Boolean(value) ||
+    Boolean(action) ||
+    Boolean(actionDescription) ||
+    Boolean(context) ||
+    Boolean(imageDescription) ||
+    Boolean(imageUrl) ||
+    (icons && icons.length > 0) ||
+    Boolean(size)
+
+  if (!hasContent) {
+    return { card: null, warnings }
+  }
+
+  const card: ImportedCardData = {}
+  if (id) card.id = id
+  if (title !== undefined) card.title = title
+  if (type !== undefined) card.type = type
+  if (value !== undefined) card.value = value
+  if (action !== undefined) card.action = action
+  if (actionDescription !== undefined) card.actionDescription = actionDescription
+  if (context !== undefined) card.context = context
+  if (imageDescription !== undefined) card.imageDescription = imageDescription
+  if (icons !== undefined) card.icons = icons
+  if (imageUrl !== undefined) card.imageUrl = imageUrl
+  if (size) card.size = size
+
+  return { card, warnings }
+}
+
+export const convertRecordsToImportedCards = (
+  records: DatasetRecord[],
+  mapping: ImportFieldMapping,
+  options: { iconSeparator?: string } = {},
+): RecordsConversionResult => {
+  const entries: ImportedCardData[] = []
+  const warnings: string[] = []
+  let skipped = 0
+
+  records.forEach((record) => {
+    const { card, warnings: rowWarnings } = mapRecordToCard(record, mapping, options)
+    warnings.push(...rowWarnings)
+    if (card) {
+      entries.push(card)
+    } else {
+      skipped += 1
+    }
+  })
+
+  return { entries, skipped, warnings }
+}


### PR DESCRIPTION
## Summary
- add parsing utilities for CSV/JSON template imports and conversion to card data
- create a data import dialog with mapping UI and integrate it into the editor workflow
- update project actions to expose import option and cover parsing logic with unit tests

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d39ccd0c1c832c9fc0cbe61da00777