### PR TITLE
Add project duplication, archiving, and filtering controls

### DIFF
--- a/cardforge/src/types/index.ts
+++ b/cardforge/src/types/index.ts
@@ -130,6 +130,7 @@ export interface Project {
   assets: ProjectAssets
   createdAt?: Date
   updatedAt?: Date
+  archivedAt?: Date | null
 }
 
 export interface ProjectListItem {
@@ -137,6 +138,7 @@ export interface ProjectListItem {
   name: string
   updatedAt?: Date
   cardCount: number
+  archivedAt?: Date | null
 }
 
 export interface JSONSchema {


### PR DESCRIPTION
## Summary
- add Firestore helpers to duplicate, archive, and restore projects while carrying over cards and assets safely
- extend project listing metadata to surface archived status and support sorting of archived entries
- refresh the project list UI with search, status filters, minimum card count filter, and new actions for duplication and archiving/restoring

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3b8a6f73c832ca64ed607f2ce1f6c